### PR TITLE
Issue-01 Multiple settings option

### DIFF
--- a/rent/rent/settings.py
+++ b/rent/rent/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from distutils.util import strtobool
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -23,10 +24,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'b&6ng_mexlgx$78fs(fvlfz%!bu#*&om#2dkp=m$@r^l6zki1a'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = strtobool(os.environ.get('DEBUG', 'True'))
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS').split(",") \
+    if os.environ.get('ALLOWED_HOSTS') else []
 
 # Application definition
 


### PR DESCRIPTION
On Linux, you can have multiple env.sh files in the production and development server that are like this:

# Dev server
export DEBUG=True
export ALLOWED_HOSTS=[]

And before running the project, type source env.sh in the command line.
