### PR TITLE
add custom setting files

### DIFF
--- a/rent/manage.py
+++ b/rent/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rent.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rent.settings.prod')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/rent/rent/settings/base.py
+++ b/rent/rent/settings/base.py
@@ -13,7 +13,8 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))))
 
 
 # Quick-start development settings - unsuitable for production
@@ -23,9 +24,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'b&6ng_mexlgx$78fs(fvlfz%!bu#*&om#2dkp=m$@r^l6zki1a'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
 
 
 # Application definition
@@ -112,9 +110,3 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/2.2/howto/static-files/
-
-STATIC_URL = '/static/'

--- a/rent/rent/settings/dev.py
+++ b/rent/rent/settings/dev.py
@@ -1,0 +1,15 @@
+from .base import *
+import os
+
+
+DEBUG = True
+ALLOWED_HOSTS = []
+
+STATICFILES_DIRS = (os.path.join(BASE_DIR, 'frontend', "build", "static"),)
+
+STATIC_URL = '/static/'
+STATIC_ROOT = 'static/'
+
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'

--- a/rent/rent/settings/prod.py
+++ b/rent/rent/settings/prod.py
@@ -1,0 +1,11 @@
+from .base import *
+
+DEBUG = False
+ALLOWED_HOSTS = [u'yourusername.pythonanywhere.com']
+
+
+STATIC_URL = '/static/'
+STATIC_ROOT = u'/home/yourusername/rent/static'
+STATIC_URL = '/static/'
+MEDIA_ROOT = u'/home/yourusername/rent/media'
+MEDIA_URL = '/media/'


### PR DESCRIPTION
I solved issue #1.
in this commit i added development and production setting file. in production file you must set pythonanywhere username.
if you want run project on local system and in development, you must change `    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rent.settings.prod')
` to `os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rent.settings.dev')
` in `manage.py` file.
